### PR TITLE
Bump log4j2.version from 2.3 to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <struts2.version>2.3.30</struts2.version>
-        <log4j2.version>2.3</log4j2.version>
+        <log4j2.version>2.13.3</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>3.0.5.RELEASE</spring.version>
     </properties>


### PR DESCRIPTION
Bumps `log4j2.version` from 2.3 to 2.13.3.

Updates `log4j-api` from 2.3 to 2.13.3

Updates `log4j-core` from 2.3 to 2.13.3

Signed-off-by: dependabot[bot] <support@github.com>